### PR TITLE
Fix List Out of Range in Loop Seer

### DIFF
--- a/angr/exploration_techniques/loop_seer.py
+++ b/angr/exploration_techniques/loop_seer.py
@@ -42,7 +42,8 @@ class LoopSeer(ExplorationTechnique):
 
         if type(loops) in (list, tuple) and all(type(l) is Loop for l in loops):
             for loop in loops:
-                self.loops[loop.entry_edges[0][0].addr] = loop
+                if len(loop.entry_edges) > 0:
+                    self.loops[loop.entry_edges[0][0].addr] = loop
 
         elif loops is not None:
             raise TypeError('What type of loop is it?')
@@ -88,8 +89,9 @@ class LoopSeer(ExplorationTechnique):
             loop_finder = self.project.analyses.LoopFinder(kb=self.cfg.kb, normalize=True, functions=func)
 
             for loop in loop_finder.loops:
-                entry = loop.entry_edges[0][0]
-                self.loops[entry.addr] = loop
+                if len(loop.entry_edges) > 0:
+                    entry = loop.entry_edges[0][0]
+                    self.loops[entry.addr] = loop
 
     def step(self, simgr, stash='active', **kwargs):
         kwargs['successor_func'] = self.normalized_step


### PR DESCRIPTION
In some cases, Loop object has no entry_edges (i.e. loop in the start of angr function), leading to a crash in Loop Seer